### PR TITLE
qbittorrent: Check if group/user already exist on startup

### DIFF
--- a/qbittorrent/rootfs/usr/bin/entrypoint.sh
+++ b/qbittorrent/rootfs/usr/bin/entrypoint.sh
@@ -6,8 +6,8 @@ set -e
 
 [[ "$DEBUG" == "true" ]] && set -x
 
-addgroup -g ${GID} qbittorrent
-adduser -h /data -s /bin/sh -G qbittorrent -D -u ${UID} qbittorrent
+getent group qbittorrent >/dev/null || addgroup -g ${GID} qbittorrent
+getent passwd qbittorrent >/dev/null || adduser -h /data -s /bin/sh -G qbittorrent -D -u ${UID} qbittorrent
 
 mkdir -p /data/.config/qBittorrent
 


### PR DESCRIPTION
Need to check whether group/user exist before trying to create them.
This is to prevent startup fails on container restart.