### PR TITLE
Updated libtorrent for qBittorrent

### DIFF
--- a/qbittorrent/Dockerfile
+++ b/qbittorrent/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11
 
 ARG QBITTORRENT_VER=4.2.3
-ARG LIBTORRENT_VER=1.2.5
+ARG LIBTORRENT_VER=1.2.6
 
 LABEL maintainer="zgist" \
         org.label-schema.name="qBittorrent" \


### PR DESCRIPTION
1.2.5 to 1.2.6

1.2.6 has fixed quite a number of connectivity problems 1.2.5 was having, it's worth to update it.