### PR TITLE
add mailx to dockerfile

### DIFF
--- a/smartmontools/Dockerfile
+++ b/smartmontools/Dockerfile
@@ -5,6 +5,6 @@ ARG VERSION
 # Let's roll
 RUN set -xe && \
     apk add --no-cache \
-    smartmontools ssmtp
+    smartmontools ssmtp mailx
 
 ENTRYPOINT ["/usr/sbin/smartd", "--debug"]


### PR DESCRIPTION
Without the package mailx, i get this error in my log. manually installing this package in this container fixed this problem. I´ve added the package to the dockerfile.

Test of <mail> to ********* produced unexpected output (56 bytes) to STDOUT/STDERR: ,
/etc/smartd_warning.sh: exec: line 192: mail: not found,
Executing test of <mail> to ********* ...

also, ssmtp is not maintained anymore. Consider moving to msmtp.