### PR TITLE
Don't disable NFS v2 explicitly

### DIFF
--- a/nfs-server/nfsd.sh
+++ b/nfs-server/nfsd.sh
@@ -5,5 +5,5 @@
 echo "$NFS_DIR $NFS_DOMAIN($NFS_OPTION)" > /etc/exports
 /usr/sbin/exportfs -r
 /sbin/rpcbind -s
-/usr/sbin/rpc.nfsd --no-udp -N 2 -N 3 8 |:
+/usr/sbin/rpc.nfsd --no-udp -N 3 8 |:
 /usr/sbin/rpc.mountd --no-udp -N 2 -N 3 -F


### PR DESCRIPTION
Since **v2.6.1** of `nfs-utils`, `nfsd` has completely dropped support for the NFS v2 protocol:

* https://salsa.debian.org/kernel-team/nfs-utils/-/commit/2c2c36c59fa1de2ff7fd28917e54700ecb39b730

Fixes https://github.com/vgist/dockerfiles/issues/35