### PR TITLE
change --log-stdout to --debug-stdout

### DIFF
--- a/samba-server/Dockerfile
+++ b/samba-server/Dockerfile
@@ -18,6 +18,6 @@ ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 
 CMD nmbd --daemon && \
     smbd --foreground \
-         --log-stdout \
+         --debug-stdout \
          --no-process-group \
          --configfile /etc/samba/smb.conf


### PR DESCRIPTION
Samba 4.15 changed `--log-stdout` to `--debug-stdout`. See https://wiki.samba.org/index.php/Samba_Features_added/changed.