### PR TITLE
add missing build dependency to qbittorrent Dockerfile

### DIFF
--- a/qbittorrent/Dockerfile
+++ b/qbittorrent/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex && \
         libcap \
         openssl-dev \
         qt6-qtbase-dev \
+        qt6-qtbase-private-dev \
         qt6-qtsvg-dev \
         qt6-qttools-dev \
         tar \


### PR DESCRIPTION
- Add missing build dependency for QT6 (>=6.10).